### PR TITLE
Add Python AI package

### DIFF
--- a/packages/ai/main.py
+++ b/packages/ai/main.py
@@ -1,0 +1,5 @@
+def main():
+    print("Hello from the AI package")
+
+if __name__ == "__main__":
+    main()

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repo/ai",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "pip install -r requirements.txt",
+    "start": "python main.py"
+  }
+}

--- a/packages/ai/requirements.txt
+++ b/packages/ai/requirements.txt
@@ -1,0 +1,1 @@
+# add your ai dependencies here

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,12 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "dist/**",
+        "packages/ai/**"
+      ]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- add an `@repo/ai` Python package with basic entrypoint
- allow installing Python dependencies when building
- cache AI package outputs in Turborepo `build` task

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c0e85ae4883249547891ea3a0dc87